### PR TITLE
pycurl bug in ubuntu 11.10

### DIFF
--- a/galicaster/utils/mhhttpclient.py
+++ b/galicaster/utils/mhhttpclient.py
@@ -64,6 +64,7 @@ class MHHTTPClient(object):
         b = StringIO()
         c.setopt(pycurl.URL, self.server + endpoint.format(**params))
         c.setopt(pycurl.FOLLOWLOCATION, False)
+        c.setopt(pycurl.NOSIGNAL, 1)
         c.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_DIGEST)
         c.setopt(pycurl.USERPWD, self.user + ':' + self.password)
         c.setopt(pycurl.HTTPHEADER, ['X-Requested-Auth: Digest'])


### PR DESCRIPTION
Galicaster was giving us segmentation faults on ubuntu 11.10 and 12.04, that seem to be related to a pycurl bug. Setting nosignal = 1 solves these segmentation faults.
