### PR TITLE
fix spelling mistake and make host and port configurable

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -52,6 +52,7 @@ cleanstale = False
 forcedurationrec = False
 shortcuts = True
 checkrepo = False
+rest = False
 
 [screensaver]
 inactivity = 120
@@ -65,6 +66,10 @@ duration = 240
 [audio]
 min = -70
 keep_closed = False
+
+[rest]
+host = 0.0.0.0
+port = 8080
 
 # MEDIA MANAGER APPEARENCE
 [color]

--- a/galicaster/core/state.py
+++ b/galicaster/core/state.py
@@ -53,7 +53,7 @@ class State(object):
                  "net" : self.net,
                  "is-recording": self.is_recording,
                  "recorder-status" : self. status,
-                 "current-prifle" : self.profile.name,
+                 "current-profile" : self.profile.name,
                  "active-area" : AREA[self.area],
                  "current-mediapackage" : self.mp}
         

--- a/galicaster/plugins/rest.py
+++ b/galicaster/plugins/rest.py
@@ -23,18 +23,22 @@ from galicaster.utils import readable
 
 """
 Description: Galicaster REST endpoint using bottle micro web-framework.
-Status: Experimental 
+Status: Experimental
 """
 
 def init():
-    restp = threading.Thread(target=run,kwargs={'host':'0.0.0.0', 'port':8080,'quiet':True})
+    conf = context.get_conf()
+    host = conf.get('rest', 'host')
+    port = conf.get_int('rest', 'port')
+
+    restp = threading.Thread(target=run,kwargs={'host': host, 'port': port, 'quiet': True})
     restp.setDaemon(True)
     restp.start()
 
 
 @route('/')
 def index():
-    response.content_type = 'application/json' 
+    response.content_type = 'application/json'
     state = context.get_state()
     text="Galicaster REST endpoint plugin\n\n"
     endpoints = {


### PR DESCRIPTION
Made some changes to move to port and host a config setting instead of hard coded. This enables the use of the rest interface on localhost only for monitoring purposes.
