### PR TITLE
Make sure state.is_recording is always correct.

### DIFF
--- a/galicaster/classui/recorderui.py
+++ b/galicaster/classui/recorderui.py
@@ -1136,7 +1136,6 @@ class RecorderClassUI(gtk.Box):
             prevb.set_sensitive(False)
             editb.set_sensitive(True and not self.scheduled_recording)    
             self.dispatcher.emit("update-rec-status", "  Recording  ")
-            context.get_state().is_recording=True
        
         elif state == GC_PAUSED:
             record.set_sensitive(False)

--- a/galicaster/recorder/recorder.py
+++ b/galicaster/recorder/recorder.py
@@ -130,6 +130,7 @@ class Recorder(object):
 
     def record(self):
         if self.pipeline.get_state()[1] == gst.STATE_PLAYING:
+            context.get_state().is_recording=True
             for bin_name, bin in self.bins.iteritems():
                 valve = bin.changeValve(False)                
             # Get clock
@@ -137,6 +138,7 @@ class Recorder(object):
     def stop_record(self):                
         a = gst.structure_from_string('letpass')
         event = gst.event_new_custom(gst.EVENT_EOS, a)
+        context.get_state().is_recording=False
         for bin_name, bin in self.bins.iteritems():
             resultado = bin.send_event_to_src(event)
             #if resultado: 
@@ -145,12 +147,7 @@ class Recorder(object):
 
     def stop_record_and_restart_preview(self):
         logger.debug("Stopping Recording and Restarting Preview")
-        a = gst.structure_from_string('letpass')
-        event = gst.event_new_custom(gst.EVENT_EOS, a)
-        for bin_name, bin in self.bins.iteritems():
-            resultado = bin.send_event_to_src(event)
-            #if resultado: 
-            #    print "EOS sended to src of: " + bin_name
+        self.stop_record()
         self.restart = True  # FIXME send user_data on the EOS to force restart
         if self.pipeline.get_state()[1] == gst.STATE_PAUSED: 
             # If paused ensure sending EOS


### PR DESCRIPTION
previously it was never set to False after a recording. i think it is probably best to keep this status in sync within Recorder but maybe there is a better option?
