### PR TITLE
set recording state on matterhorn server when doing manual recording.

### DIFF
--- a/galicaster/core/context.py
+++ b/galicaster/core/context.py
@@ -188,7 +188,7 @@ def get_scheduler():
     if 'scheduler' not in __galicaster_context:
         if get_conf().get_boolean("ingest", "active"):
             sch = Scheduler(get_repository(), get_conf(), get_dispatcher(), 
-                            get_mhclient(), get_logger())
+                            get_mhclient(), get_logger(), get_state())
         else:
             sch = None
         __galicaster_context['scheduler'] = sch

--- a/galicaster/scheduler/scheduler.py
+++ b/galicaster/scheduler/scheduler.py
@@ -21,13 +21,14 @@ from galicaster.mediapackage import mediapackage
 
 class Scheduler(object):
 
-    def __init__(self, repo, conf, disp, mhclient, logger):
+    def __init__(self, repo, conf, disp, mhclient, logger, state):
         """
         Arguments:
         repo -- the galicaster mediapackage repository
         conf -- galicaster configuration
         disp -- the galicaster event-dispatcher to emit signals
         mhclient -- matterhorn HTTP client
+        state -- galicaster state
         """
         self.ca_status = 'idle'
 
@@ -36,6 +37,7 @@ class Scheduler(object):
         self.dispatcher = disp
         self.client     = mhclient
         self.logger     = logger
+        self.state      = state
 
         self.dispatcher.connect('galicaster-notify-timer-short', self.do_timers_short)
         self.dispatcher.connect('galicaster-notify-timer-long',  self.do_timers_long)
@@ -87,6 +89,7 @@ class Scheduler(object):
 
 
     def set_state(self):
+        self.ca_status = 'capturing' if self.state.is_recording else 'idle'
         self.logger.info('Set status %s to server', self.ca_status)
         try:
             self.client.setstate(self.ca_status)


### PR DESCRIPTION
possible fix for issue #40

not sure if this is the best way of doing it but it seems to work ok. there are lots of places in the code where the status gets updated and none of them seemed like the right place to put this so i ended up doing it in the scheduler method that actually calls the stuff to set the state on matterhorn.
