### PR TITLE
Allow any case for plugin config values

### DIFF
--- a/galicaster/plugins/__init__.py
+++ b/galicaster/plugins/__init__.py
@@ -21,7 +21,7 @@ def init():
 
     list_plugins = conf.get_section('plugins')
     for plugin, v in list_plugins.iteritems():
-        if v == 'True':
+        if v.lower() == 'true':
             try:
                 name = 'galicaster.plugins.' + plugin
                 __import__(name)


### PR DESCRIPTION
Plugins were only activated if value was "True", values of "true" or "TRUE" failed.
