### PR TITLE
F/failovermic rm manc

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -92,6 +92,7 @@ pushpic = False
 setuprecording = False
 hidetabs = False
 retryingest = False
+failovermic = False
 
 [screensaver]
 inactivity = 120
@@ -118,6 +119,17 @@ port = 8080
 [retryingest]
 check_after = 300
 check_published = True
+
+; 'device' is the pulse audio device that will be used to record the failover audio track.
+; 'failover_threshold' is the threshold rms amplitude at which the audio will be replaced.
+; this number is between -100 and 0
+; the galicaster vumeter gives a rough visual indication of this value.
+; 'audio_device' if multiple audio sources are used, this number corresponds
+; to the audio track to replace. 1 = the first audio track.
+[failovermic]
+device = default
+failover_threshold = -50
+audio_device = 1
 
 ;; Configuration for the setuprecording plugin.
 ;; The following keys define the values that will be pre-filled in the metadata editor

--- a/galicaster/plugins/failovermic.py
+++ b/galicaster/plugins/failovermic.py
@@ -54,7 +54,6 @@ def init():
 
 def set_pipeline():
     # create the gstreamer elements; pulse source mp3 192kbps cbr
-    # FIXME hardcoded properties
     faudiosrc = gst.element_factory_make("pulsesrc", "pulsesrc")
     if device is None:
         faudiosrc.set_property("device", "{0}".format(default_device))
@@ -157,14 +156,6 @@ def failover_audio(self, mpUri):
                     logger.debug('Examine track type %s', mimetype)
                     if mimetype.split('/')[0].lower() == 'audio':
                         mp.remove(t)
-                    else:
-                        if mimetype.split('/')[1].lower() == 'mp4':
-                            t_path = t.getURI()
-                            output_file = t_path.split('.')[0] + '_1.' + t_path.split('.')[1]
-                            cmd = "avconv -y -i {0} -acodec copy -an {1}".format(t_path, output_file)
-                            os.system(cmd)
-                            os.remove(t_path)
-                            os.rename(output_file, t_path)
                 filename = get_audio_track()
                 dest = os.path.join(mpUri, os.path.basename(filename))
                 shutil.copyfile(FAILOVER_FILE, dest)


### PR DESCRIPTION
This plugin will record an audio gstreamer pipeline to file from a second audio source for example a USB microphone. When a recording has finished it compares the levels of the recorded mediapackage audio with a defined threshold. This uses the same signal as the vumeter. If the audio is quite (never goes over that threshold) then the audio in the media package is replaced with the failover audio file.
