### PR TITLE
retryingest optional nightly delay

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -115,9 +115,11 @@ port = 8080
 ;; check_published is whether to check that the mediapackage is already published
 ;; on the matterhorn server and if so, sets the ingest state to succeeded
 ;; without reingesting.
+;; check_nightly will mark the mediapackage as 'nightly' and postpone the ingest.
 [retryingest]
 check_after = 300
 check_published = True
+check_nightly = False
 
 ;; Configuration for the setuprecording plugin.
 ;; The following keys define the values that will be pre-filled in the metadata editor


### PR DESCRIPTION
Addition of a nightly delay rather than immediate ingest to the retryingest plugin if specified in the config for the plugin. also the addition of only checking the mediapackage when the recording has completed. This could be useful as often immediate ingests that fail could be due to network/server load so postponing until a quiet time could alleviate this
