### PR TITLE
Properly take the thread mutex before entering the mainloop

### DIFF
--- a/run_galicaster.py
+++ b/run_galicaster.py
@@ -32,6 +32,7 @@ def main(args):
         return usage()
     try:
         gc = core.Main()
+        gtk.gdk.threads_enter()
         gtk.main()
     except KeyboardInterrupt:
         gc.emit_quit()


### PR DESCRIPTION
This fixes a bug similar to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=758619 :
with glib2 >= 2.42, galicaster fails with the message
Attempt to unlock mutex that was not locked

This patch solves this issue.
