### PR TITLE
This fix a problem when you proxy the matterhorn server

### DIFF
--- a/galicaster/utils/mhhttpclient.py
+++ b/galicaster/utils/mhhttpclient.py
@@ -87,7 +87,7 @@ class MHHTTPClient(object):
         b = StringIO()
 
         url = list(urlparse.urlparse(theServer, 'http'))
-        url[2] = endpoint.format(**path_params)
+        url[2] = url[2] + endpoint.format(**path_params)
         url[4] = urllib.urlencode(query_params)
         c.setopt(pycurl.URL, urlparse.urlunparse(url))
 


### PR DESCRIPTION
This fix a problem when you proxy the matterhorn server in an URL that is not the root folder of the server.

Our MH server has an URL like http://proxyserver.com/matterhorn
This works ok in Galicaster 1.3.x, but in Galicaster 1.4.x it's not working because Galicaster try to call to
http://proxyserver.com/recordings/calendar instead of http://proxyserver.com/matterhorn/recordings/calendar
This pull request solves this.
