### PR TITLE
Added ref/mimetype attributes to mediapackage  attachments

### DIFF
--- a/galicaster/mediapackage/deserializer.py
+++ b/galicaster/mediapackage/deserializer.py
@@ -67,9 +67,14 @@ def fromXML(xml, logger=None):
             mime = _checknget(i, "mimetype")
             duration = _checknget(i, "duration")
             element_path = _getElementAbsPath(uri, mp.getURI())
+            ref = unicode(i.getAttribute("ref"))
+            if i.hasAttribute("ref"):
+            	ref = unicode(i.getAttribute("ref"))
+            else:
+                ref = None
             if not path.exists(element_path):
                 raise IOError, "Not exists the element {} in the MP {}".format(element_path, mp.identifier)
-            mp.add(element_path, etype, flavor, mime, duration, identifier)
+            mp.add(element_path, etype, flavor, mime, duration, ref, identifier)
 
             if uri == 'org.opencastproject.capture.agent.properties' and etype == mediapackage.TYPE_ATTACHMENT:
                 mp.manual = False

--- a/galicaster/mediapackage/mediapackage.py
+++ b/galicaster/mediapackage/mediapackage.py
@@ -155,7 +155,7 @@ class Element(object):
     
     def setMimeType(self, mime):
         self.mime = mime
-    
+
     def getFlavor(self):
         return self.flavor
     
@@ -213,9 +213,17 @@ class Attachment(Element):
     """
     Arquivos adxuntos dun MP
     """
-    def __init__(self, uri, flavor=None, mimetype=None, identifier=None):
+    def __init__(self, uri, flavor=None, mimetype=None, identifier=None, ref=None):
         super(Attachment, self).__init__(uri=uri, flavor=flavor, mimetype=mimetype, identifier=identifier)
         self.etype = TYPE_ATTACHMENT
+	self.ref = ref
+
+    def getRef(self):
+        return self.ref
+    
+    def setRef(self, ref):
+        self.ref = ref
+    
 
 
 
@@ -568,7 +576,7 @@ class Mediapackage(object):
     def hasUnclassifiedElements(self):
         return self.hasElements(TYPE_OTHER)
     
-    def add(self, item, etype=None, flavor=None, mime=None, duration=None, identifier=None): # FIXME incluir starttime?
+    def add(self, item, etype=None, flavor=None, mime=None, duration=None, ref=None, identifier=None): # FIXME incluir starttime?
         if isinstance(item, Element):
             elem = item
             etype = elem.getElementType()
@@ -578,7 +586,7 @@ class Mediapackage(object):
                 if etype == TYPE_TRACK:
                     elem = Track(uri=item, duration=duration, flavor=flavor, mimetype=mime, identifier=identifier)
                 elif etype == TYPE_ATTACHMENT:
-                    elem = Attachment(uri=item, flavor=flavor, mimetype=mime, identifier=identifier)
+                    elem = Attachment(uri=item, flavor=flavor, mimetype=mime, ref=ref, identifier=identifier)
                 elif etype == TYPE_CATALOG:
                     elem = Catalog(uri=item, flavor=flavor, mimetype=mime, identifier=identifier)
                 else: 

--- a/galicaster/mediapackage/serializer.py
+++ b/galicaster/mediapackage/serializer.py
@@ -234,9 +234,15 @@ def set_manifest(mp, use_namespace=True):
     for a in mp.getAttachments():
         attachment = doc.createElement("attachment")
         attachment.setAttribute("id", a.getIdentifier())
+        attachment.setAttribute("type", a.getFlavor())
+        attachment.setAttribute("ref", a.getRef())
         loc = doc.createElement("url")
         uutext = doc.createTextNode(path.basename(a.getURI()))
         loc.appendChild(uutext)
+        mim = doc.createElement("mimetype")
+        mmtext = doc.createTextNode(c.getMimeType())
+        mim.appendChild(mmtext)
+        attachment.appendChild(mim)
         attachment.appendChild(loc)
         attachments.appendChild(attachment)   
         


### PR DESCRIPTION
Add ref and type attributes to the attachments.

We need this because one we are developing a plugin to galicaster to take photos every X time. Each photo is added to the mediapackage as an attachment and we need these parameters to pass it to matterhorn.
