### PR TITLE
Fixed a bug when attachment has not mimetype info

### DIFF
--- a/galicaster/mediapackage/mediapackage.py
+++ b/galicaster/mediapackage/mediapackage.py
@@ -474,6 +474,8 @@ class Mediapackage(object):
         return results
              
     def getElementById(self, identifier, etype=None):
+        if identifier not in self.elements:
+            return None     
         elem = self.elements[identifier]
         if etype == None or elem.getElementType() == etype:
             return elem

--- a/galicaster/mediapackage/serializer.py
+++ b/galicaster/mediapackage/serializer.py
@@ -239,10 +239,11 @@ def set_manifest(mp, use_namespace=True):
         loc = doc.createElement("url")
         uutext = doc.createTextNode(path.basename(a.getURI()))
         loc.appendChild(uutext)
-        mim = doc.createElement("mimetype")
-        mmtext = doc.createTextNode(a.getMimeType())
-        mim.appendChild(mmtext)
-        attachment.appendChild(mim)
+        if (a.getMimeType() != None):
+            mim = doc.createElement("mimetype")
+            mmtext = doc.createTextNode(a.getMimeType())
+            mim.appendChild(mmtext)
+            attachment.appendChild(mim)
         attachment.appendChild(loc)
         attachments.appendChild(attachment)   
         


### PR DESCRIPTION
This solves two bugs:
 - One when the attachment has no mimetype info.
 - The other one, when calling getElementById() and the identifier does not exists