### PR TITLE
Add half opacity to insensitive buttons

### DIFF
--- a/resources/ui/style.css
+++ b/resources/ui/style.css
@@ -10,6 +10,11 @@
 	font-size: 10px;
 }
 
+/* BUTTONS */
+GtkButton:insensitive{
+	opacity: 0.5;
+}
+
 /* DIALOG */
 GtkDialog{
 	border: 1px solid rgb(201,198,194);


### PR DESCRIPTION
The content of every insensitive button is now with 50% opacity to intensify this effect.