### PR TITLE
Fix noaudio dialog when next dialog it's launched and a recording starts TTK-11832

### DIFF
--- a/galicaster/plugins/noaudiodialog.py
+++ b/galicaster/plugins/noaudiodialog.py
@@ -85,6 +85,10 @@ def __check_dialog():
     global no_audio
 
     if not keep_hidden and no_audio and focus_is_active:
+        windows = context.get_mainwindow().list_toplevels()
+        for w in windows:
+            if w.get_modal():
+                return False
         no_audio_dialog.show()
     else:
         no_audio_dialog.hide()


### PR DESCRIPTION
Before launch noaudio check if any modal it's launched.