### PR TITLE
Fix #489 : The "No Audio" dialog is not correctly displayed when Galicaster is in "admin" mode and the start screen is "recording" 

### DIFF
--- a/galicaster/core/core.py
+++ b/galicaster/core/core.py
@@ -95,6 +95,9 @@ class Main():
             logger.info("Set {} as home page, modules loaded: {}".format(homepage, self.modules))
             self.window.set_current_page(PAGES[homepage])
 
+        # Notify home page setting by issuing a 'view-changed' signal
+        self.dispatcher.emit('view-changed', None, self.window.set_current_page())
+
         context.get_heartbeat().init_timer()
         self.dispatcher.emit("init")
 

--- a/galicaster/plugins/noaudiodialog.py
+++ b/galicaster/plugins/noaudiodialog.py
@@ -41,7 +41,6 @@ def init():
     global no_audio_dialog
 
     dispatcher = context.get_dispatcher()
-    conf = context.get_conf()
     no_audio_dialog = create_ui()
 
     dispatcher.connect('audio-mute', warning_audio_show)

--- a/galicaster/plugins/noaudiodialog.py
+++ b/galicaster/plugins/noaudiodialog.py
@@ -30,7 +30,7 @@ lock = Lock()
 
 no_audio = False
 no_audio_dialog = None
-focus_is_active = True
+focus_is_active = False
 keep_hidden = False
 old_keep_hidden = False
 was_shown = False
@@ -43,8 +43,6 @@ def init():
     dispatcher = context.get_dispatcher()
     conf = context.get_conf()
     no_audio_dialog = create_ui()
-
-    focus_is_active = not conf.get_boolean('basic','admin')
 
     dispatcher.connect('audio-mute', warning_audio_show)
     dispatcher.connect('audio-recovered', warning_audio_hide)


### PR DESCRIPTION
This pull request should fix the issue.