### PR TITLE
Sort conf-dist.ini options

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -98,6 +98,18 @@ processing = #FFAE00 ; orange
 done = #88FF88 ; green
 failed = #FFAEAE ;red
 
+;; OPERATIONS OPTIONS
+;; A space-separated list of operations that are to be hidden in the
+;; corresponding pop up in the manager UI.
+;; The possible values for both parameters are (unquoted):
+;;     'ingest', 'exporttozip' and 'sidebyside'
+;[operations]
+;hide = ingest exporttozip sidebyside
+;hide_nightly = ingest exporttozip sidebyside
+[operations]
+hide =
+hide_nightly =
+
 ; PLUGINS
 [plugins]
 noaudiodialog = True
@@ -209,19 +221,6 @@ audio_device = 1
 ;;   - default: Name of the tab that will be initially displayed in the UI
 ;;              Possible values are: 'events', 'recording' and 'status' (unquoted)
 ;[hidetabs]
-
-
-;; OPERATIONS OPTIONS
-;; A space-separated list of operations that are to be hidden in the
-;; corresponding pop up in the manager UI.
-;; The possible values for both parameters are (unquoted):
-;;     'ingest', 'exporttozip' and 'sidebyside'
-;[operations]
-;hide = ingest exporttozip sidebyside
-;hide_nightly = ingest exporttozip sidebyside
-[operations]
-hide =
-hide_nightly =
 
 [track1]
 name = Bars

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -28,6 +28,10 @@ stop = False
 pause = True
 overlap = True
 
+[audio]
+min = -76
+keep_closed = False
+
 [recorder]
 autorecover = False
 pausetype = pipeline
@@ -167,10 +171,6 @@ checkoninit = False
 ; Duration in minutes
 [forcedurationrec]
 duration = 240
-
-[audio]
-min = -76
-keep_closed = False
 
 [rest]
 host = 127.0.0.1

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -134,20 +134,42 @@ screensaver = False
 setuprecording = False
 shortcuts = True
 
+[appearance]
+hidecursor = False
+settings = {"/org/compiz/profiles/unity/plugins/unityshell/reveal-trigger": "1", "/org/compiz/profiles/unity/plugins/unityshell/launcher-hide-mode" : "1", "/org/compiz/profiles/unity/plugins/core/hsize": "1", "/org/compiz/profiles/unity/plugins/core/vsize" : "1"}
+defaultsettings = {"/org/compiz/profiles/unity/plugins/unityshell/reveal-trigger": "0", "/org/compiz/profiles/unity/plugins/unityshell/launcher-hide-mode" : "0", "/org/compiz/profiles/unity/plugins/core/hsize": "2", "/org/compiz/profiles/unity/plugins/core/vsize" : "2"}
+
 [cameracontrol]
 path = /dev/ttyUSB0
 zoom_levels = 7
 max_speed_pan_tilt = 0x18
 
-[muteinputs]
-mute_on_startup = False
-bins =
-mute_type = input
+[cleanstale]
+maxarchivaldays = 30
+checkoninit = False
 
-[appearance]
-hidecursor = False
-settings = {"/org/compiz/profiles/unity/plugins/unityshell/reveal-trigger": "1", "/org/compiz/profiles/unity/plugins/unityshell/launcher-hide-mode" : "1", "/org/compiz/profiles/unity/plugins/core/hsize": "1", "/org/compiz/profiles/unity/plugins/core/vsize" : "1"}
-defaultsettings = {"/org/compiz/profiles/unity/plugins/unityshell/reveal-trigger": "0", "/org/compiz/profiles/unity/plugins/unityshell/launcher-hide-mode" : "0", "/org/compiz/profiles/unity/plugins/core/hsize": "2", "/org/compiz/profiles/unity/plugins/core/vsize" : "2"}
+; 'device' is the pulse audio device that will be used to record the failover audio track.
+; 'failover_threshold' is the threshold rms amplitude at which the audio will be replaced.
+; this number is between -100 and 0
+; the galicaster vumeter gives a rough visual indication of this value.
+; 'audio_device' if multiple audio sources are used, this number corresponds
+; to the audio track to replace. 1 = the first audio track.
+[failovermic]
+device = default
+failover_threshold = -50
+audio_device = 1
+
+; Duration in minutes
+[forcedurationrec]
+duration = 240
+
+;; This is the configuration section for the plugin hidetabs.py
+;; The currently available configuration keys are:
+;;   - hide: A space-separated list of tabs that will be hidden in the record UI
+;;           Possible values are: 'events', 'recording' and 'status' (unquoted)
+;;   - default: Name of the tab that will be initially displayed in the UI
+;;              Possible values are: 'events', 'recording' and 'status' (unquoted)
+;[hidetabs]
 
 [lockscreen]
 password = 1234
@@ -159,18 +181,10 @@ ldapdc =
 ldapusertype = cn
 enable_quit_button = True
 
-[screensaver]
-inactivity = 120
-powersettings = {"/org/gnome/desktop/screensaver/lock-enabled":"false", "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend" : "false", "/org/gnome/desktop/screensaver/idle-activation-enabled":"false", "/org/gnome/settings-daemon/plugins/power/sleep-display-ac": "0", "/org/gnome/settings-daemon/plugins/power/sleep-display-battery" : "0", "/org/gnome/settings-daemon/plugins/power/active": "false", "/org/gnome/desktop/session/idle-delay": "0"}
-defaultpowersettings = {"/org/gnome/desktop/screensaver/lock-enabled":"true", "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend" : "true", "/org/gnome/desktop/screensaver/idle-activation-enabled":"true", "/org/gnome/settings-daemon/plugins/power/sleep-display-ac": "0", "/org/gnome/settings-daemon/plugins/power/sleep-display-battery" : "0", "/org/gnome/settings-daemon/plugins/power/active": "false", "/org/gnome/desktop/session/idle-delay": "600"}
-
-[cleanstale]
-maxarchivaldays = 30
-checkoninit = False
-
-; Duration in minutes
-[forcedurationrec]
-duration = 240
+[muteinputs]
+mute_on_startup = False
+bins =
+mute_type = input
 
 [rest]
 host = 127.0.0.1
@@ -187,16 +201,10 @@ check_after = 300
 check_published = True
 nightly = False
 
-; 'device' is the pulse audio device that will be used to record the failover audio track.
-; 'failover_threshold' is the threshold rms amplitude at which the audio will be replaced.
-; this number is between -100 and 0
-; the galicaster vumeter gives a rough visual indication of this value.
-; 'audio_device' if multiple audio sources are used, this number corresponds
-; to the audio track to replace. 1 = the first audio track.
-[failovermic]
-device = default
-failover_threshold = -50
-audio_device = 1
+[screensaver]
+inactivity = 120
+powersettings = {"/org/gnome/desktop/screensaver/lock-enabled":"false", "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend" : "false", "/org/gnome/desktop/screensaver/idle-activation-enabled":"false", "/org/gnome/settings-daemon/plugins/power/sleep-display-ac": "0", "/org/gnome/settings-daemon/plugins/power/sleep-display-battery" : "0", "/org/gnome/settings-daemon/plugins/power/active": "false", "/org/gnome/desktop/session/idle-delay": "0"}
+defaultpowersettings = {"/org/gnome/desktop/screensaver/lock-enabled":"true", "/org/gnome/desktop/screensaver/ubuntu-lock-on-suspend" : "true", "/org/gnome/desktop/screensaver/idle-activation-enabled":"true", "/org/gnome/settings-daemon/plugins/power/sleep-display-ac": "0", "/org/gnome/settings-daemon/plugins/power/sleep-display-battery" : "0", "/org/gnome/settings-daemon/plugins/power/active": "false", "/org/gnome/desktop/session/idle-delay": "600"}
 
 ;; Configuration for the setuprecording plugin.
 ;; The following keys define the values that will be pre-filled in the metadata editor
@@ -212,15 +220,6 @@ audio_device = 1
 ;;             For instance: "presenter = {user}" will set up the default presenter
 ;;             value to the current user
 ;[setuprecording]
-
-
-;; This is the configuration section for the plugin hidetabs.py
-;; The currently available configuration keys are:
-;;   - hide: A space-separated list of tabs that will be hidden in the record UI
-;;           Possible values are: 'events', 'recording' and 'status' (unquoted)
-;;   - default: Name of the tab that will be initially displayed in the UI
-;;              Possible values are: 'events', 'recording' and 'status' (unquoted)
-;[hidetabs]
 
 ;; TEST PROFILE CONFIGURATION
 ;; --------------------------

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -95,6 +95,23 @@ night = 00:00
 [sidebyside]
 layout = sbs ;Side by side layout. Possible values: pip-screen, pip-camera
 
+;; UI OPTIONS
+;; ----------
+
+[help]
+main = Visit galicaster.teltek.es
+text = ...or contact us on our community list.
+
+;MEDIA MANAGER APPEARANCE
+[color]
+classic = false
+none =  #FFF0AA ;yellow
+nightly = #AEFFAE ; light green
+pending = #AEFFAE ; light green
+processing = #FFAE00 ; orange
+done = #88FF88 ; green
+failed = #FFAEAE ;red
+
 ; PLUGINS
 [plugins]
 noaudiodialog = True
@@ -198,7 +215,6 @@ audio_device = 1
 ;;             value to the current user
 ;[setuprecording]
 
-;; UI OPTIONS
 
 ;; This is the configuration section for the plugin hidetabs.py
 ;; The currently available configuration keys are:
@@ -220,21 +236,6 @@ audio_device = 1
 [operations]
 hide =
 hide_nightly =
-
-[help]
-main = Visit galicaster.teltek.es
-text = ...or contact us on our community list.
-
-;MEDIA MANAGER APPEARENCE
-[color]
-classic = false
-none =  #FFF0AA ;yellow
-nightly = #AEFFAE ; light green
-pending = #AEFFAE ; light green
-processing = #FFAE00 ; orange
-done = #88FF88 ; green
-failed = #FFAEAE ;red
-
 
 [track1]
 name = Bars

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -222,6 +222,9 @@ audio_device = 1
 ;;              Possible values are: 'events', 'recording' and 'status' (unquoted)
 ;[hidetabs]
 
+;; TEST PROFILE CONFIGURATION
+;; --------------------------
+
 [track1]
 name = Bars
 pattern = 0

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -35,6 +35,9 @@ pausetype = pipeline
 [repository]
 foldertemplate = gc_{hostname}_{year}-{month}-{day}T{hour}h{minute}m{second}
 
+[sidebyside]
+layout = sbs ;Side by side layout. Possible values: pip-screen, pip-camera
+
 ;; Metadata editor configuration
 ;; Two parameters are available:
 ;;   - blocked: a blank-separated list of metadata fields that will be non-editable by the user
@@ -91,9 +94,6 @@ ignore_capture_devices = False
 short = 10
 long = 60
 night = 00:00
-
-[sidebyside]
-layout = sbs ;Side by side layout. Possible values: pip-screen, pip-camera
 
 ;; UI OPTIONS
 ;; ----------

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -38,20 +38,6 @@ foldertemplate = gc_{hostname}_{year}-{month}-{day}T{hour}h{minute}m{second}
 [sidebyside]
 layout = sbs ;Side by side layout. Possible values: pip-screen, pip-camera
 
-;; Metadata editor configuration
-;; Two parameters are available:
-;;   - blocked: a blank-separated list of metadata fields that will be non-editable by the user
-;;   - mandatory: a blank-separated list of metadata fields that MUST NOT be blank in order to
-;;                apply the changes to the mediapackage
-;;
-;; Both parameters admit the following values (unquoted):
-;;   - 'title'
-;;   - 'presenter' or 'creator'
-;;   - 'description'
-;;   - 'language'
-;;   - 'series', 'ispartof' or 'isPartOf'
-;[metadata]
-
 ; OPENCAST COMMUNICATION
 [ingest]
 hostname = 

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -1,3 +1,5 @@
+;; BASIC CONFIGURATION
+;; -------------------
 [basic]
 admin = True
 profile = Default
@@ -12,14 +14,26 @@ resolution = auto
 legacy = False
 tmp =
 
-[repository]
-foldertemplate = gc_{hostname}_{year}-{month}-{day}T{hour}h{minute}m{second}
-
 [logger]
 path = logs/galicaster.log
 level = DEBUG
 rotate = False
 use_syslog = False
+
+; OVERLAPPING AND RECORDING OPTIONS
+[allows]
+manual = True
+start = False
+stop = False
+pause = True
+overlap = True
+
+[recorder]
+autorecover = False
+pausetype = pipeline
+
+[repository]
+foldertemplate = gc_{hostname}_{year}-{month}-{day}T{hour}h{minute}m{second}
 
 ;; Metadata editor configuration
 ;; Two parameters are available:
@@ -80,14 +94,6 @@ night = 00:00
 
 [sidebyside]
 layout = sbs ;Side by side layout. Possible values: pip-screen, pip-camera
-
-; OVERLAPPING AND RECORDINGS OPTIONS
-[allows]
-manual = True
-start = False
-stop = False
-pause = True
-overlap = True
 
 ; PLUGINS
 [plugins]
@@ -214,10 +220,6 @@ audio_device = 1
 [operations]
 hide =
 hide_nightly =
-
-[recorder]
-autorecover = False
-pausetype = pipeline
 
 [help]
 main = Visit galicaster.teltek.es

--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -116,23 +116,23 @@ hide_nightly =
 
 ; PLUGINS
 [plugins]
-noaudiodialog = True
-screensaver = False
-cleanstale = False
-forcedurationrec = False
-shortcuts = True
-checkrepo = False
-rest = False
-pushpic = False
-setuprecording = False
-hidetabs = False
-retryingest = False
-failovermic = False
-keyboard = False
-lockscreen = False
 appearance = False
 cameracontrol = False
+checkrepo = False
+cleanstale = False
+failovermic = False
+forcedurationrec = False
+hidetabs = False
+keyboard = False
+lockscreen = False
 muteinputs = False
+noaudiodialog = True
+pushpic = False
+rest = False
+retryingest = False
+screensaver = False
+setuprecording = False
+shortcuts = True
 
 [cameracontrol]
 path = /dev/ttyUSB0


### PR DESCRIPTION
This pull request tidies the conf-dist.ini options for easier navigation.
The only options deleted were the old "Metadata Editor", the rest were just sorted around.