### PR TITLE
add option to dump dot file of gstreamer pipeline.

### DIFF
--- a/galicaster/recorder/recorder.py
+++ b/galicaster/recorder/recorder.py
@@ -143,6 +143,10 @@ class Recorder(object):
             bin.changeValve(True)
         self.__valves_status = True
         self.__set_state(Gst.State.PLAYING)
+        Gst.debug_bin_to_dot_file_with_ts(self.pipeline,
+                                          Gst.DebugGraphDetails.ALL,
+                                          'galicaster-pipeline')
+
 
 
     def preview_and_record(self):


### PR DESCRIPTION
Set `GST_DEBUG_DUMP_DOT_DIR` env var to a path in order to activate.
Does nothing if not set.

use `xdot` to view the files directly or convert to png with
graphviz eg. `dot -Tpng input.dot -o output.png`.

very handy for debugging profile/bin issues