### PR TITLE
fix paused exception

### DIFF
--- a/galicaster/classui/recorderui.py
+++ b/galicaster/classui/recorderui.py
@@ -730,7 +730,9 @@ class RecorderClassUI(Gtk.Box):
             helpb.set_sensitive(True)
             prevb.set_sensitive(False)
             swapb.set_sensitive(False)
-            editb.set_sensitive(self.recorder.current_mediapackage and self.recorder.current_mediapackage.manual)
+            editb.set_sensitive((self.recorder.current_mediapackage
+                                and self.recorder.current_mediapackage.manual)
+                                or False)
 
         elif status == PAUSED_STATUS:
             record.set_sensitive(False)


### PR DESCRIPTION
`recorder.current_mediapackage` can be `None` so this makes sure it is
a boolean as required.

fixes #513