### PR TITLE
allows setting of pause dialog size in the conf.ini

### DIFF
--- a/galicaster/classui/recorderui.py
+++ b/galicaster/classui/recorderui.py
@@ -157,6 +157,12 @@ class RecorderClassUI(Gtk.Box):
         # OTHER
         builder.connect_signals(self)
         self.net_activity = self.conf.get_boolean('ingest', 'active')
+        self.pausedialog_size = self.conf.get_int('basic', 'pausedialog_size',
+                                                  default=15)
+        if self.pausedialog_size < 5:
+            self.pausedialog_size = 5
+        elif self.pausedialog_size > 100:
+            self.pausedialog_size = 100
 
         self.proportion = 1
 
@@ -252,13 +258,12 @@ class RecorderClassUI(Gtk.Box):
         dialog.set_modal(True)
         dialog.set_keep_above(False)
         dialog.set_skip_taskbar_hint(True)
-        size = context.get_mainwindow().get_size()
-        k2 = size[1] / 1080.0
-        size = int(k2*150)
+        scale = context.get_mainwindow().get_size()[1] / 100.0
+        size = int(scale*self.pausedialog_size)
         dialog.set_default_size(size,size)
         button = gui.get_object("image")
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file(get_image_path('gc-pause.svg'))
-        pixbuf = pixbuf.scale_simple(size, size, GdkPixbuf.InterpType.BILINEAR)
+        pause_svg = get_image_path('gc-pause.svg')
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(pause_svg, size, size)
         button.set_from_pixbuf(pixbuf)
         return dialog
 


### PR DESCRIPTION
our users had trouble with the tiny default pause button. they
often tried to click the disabled transport controls in the bottom
right to unpause and got confused when nothing happened.

to fix this we enlarged the pause button so that it is unmissable!

this adds that feature as a conf option:

```
[basic]
pausedialog_size = 70
```

the value is the percentage of the screen height you would like
the pause dialog to take up. 70 seems good for us.

this also scales the svg correctly to avoid a blurry icon.