### PR TITLE
Use argparse for command line arguments and add --version flag.

### DIFF
--- a/run_galicaster.py
+++ b/run_galicaster.py
@@ -12,6 +12,7 @@
 # or send a letter to Creative Commons, 171 Second Street, Suite 300,
 # San Francisco, California, 94105, USA.
 
+import argparse
 import sys
 # debug
 # import traceback
@@ -25,17 +26,15 @@ from gi.repository import Gtk     # noqa: ignore=E402
 from gi.repository import GLib    # noqa: ignore=E402
 from gi.repository import Gst     # noqa: ignore=E402
 
+from galicaster import __version__
 from galicaster.core import core  # noqa: ignore=E402
 from galicaster.core import context
 from galicaster.utils.dbusservice import AlreadyRunning
 
 def main(args):
-    def usage():
-        sys.stderr.write("usage: %s\n" % args[0])
-        return 1
-
-    if len(args) != 1:
-        return usage()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--version', action='version', version='Galicaster {version}'.format(version=__version__))
+    parser.parse_args(args=args[1:])
     try:
         Gst.init(None)
         gc = core.Main()


### PR DESCRIPTION
Using `argparse` automatically produces usage information. Example output:
```
$ ./run_galicaster.py -h
usage: run_galicaster.py [-h] [-v]

optional arguments:
  -h, --help     show this help message and exit
  -v, --version  show program's version number and exit
```
Version example:
```
$ ./run_galicaster -v
Galicaster 2.0.2
```
When invalid arguments are passed to `run_galicaster.py` the exit code is 2 (rather than 1) after this change, which is consistent with most other [bash commands](http://tldp.org/LDP/abs/html/exitcodes.html).

For this to work when installing Galicaster from the repository, the deb build scripts will need to be modified so that `/usr/bin/galicaster` passes any arguments on to `run_galicaster.py`. Currently the contents of `/usr/bin/galicaster` ignores any arguments passed to it:

```
python /usr/share/galicaster/run_galicaster.py
```