### PR TITLE
Calculate duration correctly when pipeline paused

### DIFF
--- a/galicaster/recorder/recorder.py
+++ b/galicaster/recorder/recorder.py
@@ -198,6 +198,7 @@ class Recorder(object):
 
     def pause(self):
         logger.debug("recorder paused")
+        self.__pause_timestamp = self.__query_position()
         self.__set_state(Gst.State.PAUSED)
         return True
 


### PR DESCRIPTION
I came across this when wanting to get the current duration of a recording from within a plugin..

The [pausetype configuration](https://github.com/teltek/Galicaster/blob/2.0.x/conf-dist.ini#L37) determines [which](https://github.com/teltek/Galicaster/blob/2.0.x/galicaster/recorder/service.py#L232) pause method of the Recorder is used when pausing a recording (the two methods are `pause()` or `pause_recording()`).
The [calculation](https://github.com/teltek/Galicaster/blob/2.0.x/galicaster/recorder/recorder.py#L126) to determine the current duration of the pipeline takes into account the `__pause_timestamp` property of the Recorder, however `__pause_timestamp` is only set in [pause_recording()](https://github.com/teltek/Galicaster/blob/2.0.x/galicaster/recorder/recorder.py#L206) not in [pause()](https://github.com/teltek/Galicaster/blob/2.0.x/galicaster/recorder/recorder.py#L199).
As a result, when a recording is paused and the pausetype is `pipeline`, any calls to `Recorder.get_recording_start_time()` return the incorrect duration of 1439:59. This isn't reflected in the UI because the text for the `Elapsed Time`  only updates when in the recording state, so while paused it displays a stale value.

Using the following snippet as a plugin works for testing:
```python
import datetime
from galicaster.core import context
from galicaster.utils import readable

conf = context.get_conf()
dispatcher = context.get_dispatcher()
recorder = context.get_recorder()

def init():
    dispatcher.connect('timer-short', on_timer_short)

def on_timer_short(source):
    msec = datetime.timedelta(microseconds=(round(recorder.get_recorded_time()/1000.0,-6)))
    print 'Elapsed time:', readable.long_time(msec)
```

It may be worth refactoring the RecorderService and Recorder at some point so that there is only one Recorder.pause() and Recorder.resume() each with an argument specifying the `pausetype`, for now this PR is all that is required to get the duration calculated correctly.