### PR TITLE
Reverted always forcing 'archive' tag and adding 'tags' to profile tracks configuration

### DIFF
--- a/galicaster/mediapackage/mediapackage.py
+++ b/galicaster/mediapackage/mediapackage.py
@@ -291,7 +291,6 @@ class Track(Element):
             etype (str): 'Track' (element type)
             duration (int): the given duration of the track in seconds.
         """
-        tags=["archive"]
 
         super(Track, self).__init__(uri=uri, flavor=flavor, mimetype=mimetype, identifier=identifier, tags=tags)
         self.etype = TYPE_TRACK

--- a/galicaster/mediapackage/repository.py
+++ b/galicaster/mediapackage/repository.py
@@ -571,7 +571,12 @@ class Repository(object):
                     flavour = bin['flavor'] + '/source'
                 else:
                     flavour = bin['flavor']
-                mp.add(dest, mediapackage.TYPE_TRACK, flavour, etype, duration) # FIXME MIMETYPE
+
+                tags = []
+                if 'tags' in bin:
+                    tags = bin['tags']
+
+                mp.add(dest, mediapackage.TYPE_TRACK, flavour, etype, duration, tags=tags) # FIXME MIMETYPE
             else:
                 self.logger and self.logger.info("Not adding {} to MP {}".format(bin['file'],mp.getIdentifier()))
 

--- a/galicaster/mediapackage/serializer.py
+++ b/galicaster/mediapackage/serializer.py
@@ -243,15 +243,15 @@ def set_manifest(mp, use_namespace=True):
         track.setAttribute("id", t.getIdentifier())
         track.setAttribute("type", t.getFlavor())
 
-        #TAGS
         # -- TAGS --
-        tags = doc.createElement("tags")
-        for tag_elem in t.getTags():
-            tag = doc.createElement("tag")
-            tagtext = doc.createTextNode(tag_elem)
-            tag.appendChild(tagtext)
-            tags.appendChild(tag)
-        track.appendChild(tags)
+        if t.getTags():
+            tags = doc.createElement("tags")
+            for tag_elem in t.getTags():
+                tag = doc.createElement("tag")
+                tagtext = doc.createTextNode(tag_elem)
+                tag.appendChild(tagtext)
+                tags.appendChild(tag)
+            track.appendChild(tags)
         ## --    --
 
         mime = doc.createElement("mimetype")

--- a/galicaster/recorder/base.py
+++ b/galicaster/recorder/base.py
@@ -33,6 +33,11 @@ class Base(object):
             "default": "presenter",
             "description": "Opencast flavor associated to the track",
             },
+        "tags": {
+            "type": "tags",
+            "default": [],
+            "description": "Opencast tags associated to the track",
+        },
         "location": {
             "type": "device",
             "default": "/dev/video0",

--- a/tests/mediapackage/mediapackage.py
+++ b/tests/mediapackage/mediapackage.py
@@ -287,7 +287,9 @@ class TestFunctions(TestCase):
         self.assertTrue(info.has_key('tracks'))
 
     def test_element_tags(self):
-        self.assertTrue(self.track1.getTags(), ['archive'])
+        self.assertEqual(self.track1.getTags(), [])
+        self.track1.addTag('archive')
+        self.assertEqual(self.track1.getTags(), ['archive'])
         self.track1.addTag('engage')
         self.assertTrue(self.track1.getTags(), ['archive', 'engage'])
         self.track1.removeTag('archive')


### PR DESCRIPTION
We have recently come across an issue Stephen reported some time ago at #435.

For Galicaster 2, we included 'archive' as a default tag on every track of the MP (manifest.xml of the MP). We think the default behavior should be not adding any tags, and letting the user configure which tags, if any, wants added to a track.

Thus, we have changed the default behavior so no tags are added if none are specified, and added the "tags" parameter to the profile configuration.