### PR TITLE
Add missing pausedialog_size config default (empty)

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -6,6 +6,7 @@ custom_flavors =
 profile = Default
 homepage = DIS
 stopdialog = True
+pausedialog_size =
 quit = True
 shutdown = False
 swapvideos = True


### PR DESCRIPTION
Without this, or the config option set in `conf.ini`, an error is written to the logs on start up.
This config option is fetched with the following call in `recorderui.py`:

```python
self.pausedialog_size = self.conf.get_int('basic', 'pausedialog_size', default=15)
```
The `get_int` method of conf in turn calls `get` which throws an exception if a configuration option doesn't exist. It seems to me that if you specify a default (fallback), then you don't need to care that the config option doesn't exist. Would it be sensible to rework get `get` method so that it checks for a not None default value? For example:

```python
        try:
            response = self.__conf.get(sect, opt)
            return response
        except Exception as exc:
            if self.logger and default is None:
                self.logger.error('The parameter "{0}" in section "{1}" does not exist. Exception: {2}'.format(opt, sect, exc))

        return default
```

This would **only** log an error if the config option is missing **and** a default isn't supplied. There would then be no need for any empty options in the config file to suppress error messages such as this and 5193a3c7.
At a glance it looks as though changing the `get` method to respect the default parameter would also mean that a lot of other config methods (`get_int`, `get_float`, etc) need updating to pass on the `default` parameter - they don't seem to at the moment.