### PR TITLE
Make conf.get_json return any object (not always a dictionary)

### DIFF
--- a/galicaster/core/conf.py
+++ b/galicaster/core/conf.py
@@ -337,24 +337,22 @@ class Conf(object): # TODO list get and other ops arround profile
 
 
     def get_json(self, sect, opt, default={}):
-        """Tries to return a set of values of an option in a section as a dictionary.
-        If else returns the given default value.
+        """Try to return JSON deserialized version of a config option
+        Otherwise returns the given default value.
         Args:
             sect (str): section of configuration file.
             opt (str): option of configuration file.
             default (str): default output if there is no value.
         Returns:
-            Dict: the set of values of option opt in section sect if there are no error. Default otherwise.
-        Note:
-        key = {"foo":["bar", null, 1.0, 2]}
+            Object: see JSON conversion table below. Default otherwise.
+            https://docs.python.org/2/library/json.html#json-to-py-table
         """
-        dictionary = {}
         if self.get(sect, opt):
             try:
-                dictionary = json.loads(self.get(sect, opt))
+                return json.loads(self.get(sect, opt))
             except Exception as exc:
-                self.logger and self.logger.warning('Error obtaining a json dictionary from "{0}" in section "{1}", FORCED TO "{2}". Exception: {3}'.format(opt, sect, default, exc))
-        return dictionary if dictionary else default
+                self.logger and self.logger.warning('Error deserializing JSON from "{0}" in section "{1}", FORCED TO "{2}". Exception: {3}'.format(opt, sect, default, exc))
+        return default
 
 
     def get_section(self, sect, default={}):


### PR DESCRIPTION
When fetching an empty list (`[]`) from a config option with `conf.get_json` Galicaster was instead returning this as an empty dictionary.
Specifying JSON lists in config options is quite useful as the `conf.get_list` method doesn't respect quotes or spaces in list items since it treats every space as an item delimiter.
The behaviour of `get_json` before this PR would actually allow it to return any type of JSON deserialized object as long as isn't empty so this also updates the documentation for the method as well.
There is a `get_dict` method that exists immediately before this one in `conf.py` which can be used exclusively for dictionaries though it would seem this is redundant if `get_json` can also return dictionaries?