### PR TITLE
TTK-17810 serializer/deserializer: Changed galicaster.xml format to json

### DIFF
--- a/galicaster/mediapackage/deserializer.py
+++ b/galicaster/mediapackage/deserializer.py
@@ -15,6 +15,8 @@
 from os import path
 from datetime import datetime
 from xml.dom import minidom
+import json
+
 from galicaster.mediapackage import mediapackage
 from galicaster.mediapackage.utils import _checknget, _checkget
 from galicaster.mediapackage.utils import _getElementAbsPath
@@ -46,23 +48,37 @@ def fromXML(xml, logger=None):
 
     without_galicaster = False
 
-    try:
-        galicaster = minidom.parse(path.join(mp.getURI(), 'galicaster.xml'))
-        mp.status = int(_checknget(galicaster, "status"))
-        for i in galicaster.getElementsByTagName("operation"):
-            op = unicode(i.getAttribute("key"))
-            status = _checknget(i, "status")
-            mp.setOpStatus(op, int(status))
-        for i in galicaster.getElementsByTagName("property"):
-            op = unicode(i.getAttribute("name"))
-            value = _checkget(i)
-            mp.properties[op] = unicode(value)
+    galicaster_json = False
 
+    try:
+        with open(path.join(mp.getURI(), 'galicaster.json')) as file:
+            galicaster_json = json.load(file)
     except IOError:
         if logger:
-            logger.error("The Mediapackage: "+mp.identifier+" : has no galicaster.xml file")
-        without_galicaster = True
+            logger.warning("The Mediapackage: "+mp.identifier+" : has no galicaster.json file. Trying to load outdated galicaster.xml")
+        # Keep The XML read logic for backwards compatibility:
+        try:
+            galicaster = minidom.parse(path.join(mp.getURI(), 'galicaster.xml'))
 
+            mp.status = int(_checknget(galicaster, "status"))
+            for i in galicaster.getElementsByTagName("operation"):
+                op = unicode(i.getAttribute("key"))
+                status = _checknget(i, "status")
+                mp.setOpStatus(op, int(status))
+            for i in galicaster.getElementsByTagName("property"):
+                op = unicode(i.getAttribute("name"))
+                value = _checkget(i)
+                mp.properties[op] = unicode(value)
+        except IOError:
+            if logger:
+                logger.error("The Mediapackage: "+mp.identifier+" : has no galicaster.xml or galicaster.json file")
+            without_galicaster = True
+
+    if galicaster_json and 'galicaster' in galicaster_json:
+        galicaster_json = galicaster_json['galicaster']
+        mp.status = galicaster_json['status']
+        mp.operations = galicaster_json['operations']
+        mp.properties = galicaster_json['properties']
 
     for etype, tag in mediapackage.MANIFEST_TAGS.items():
         for i in manifest.getElementsByTagName(tag):

--- a/tests/mediapackage/serializer.py
+++ b/tests/mediapackage/serializer.py
@@ -16,6 +16,7 @@
 Unit tests for `galicaster.serializer` module.
 """
 import zipfile
+import json
 from os import path,remove
 from shutil import rmtree
 from tempfile import mkdtemp, mkstemp
@@ -76,7 +77,7 @@ class TestFunctions(TestCase):
             raise AssertionError("Error in serializer.set_episode")
 
         try:
-            parseString(serializer.set_properties(mp))
+            json.loads(serializer.set_properties(mp))
         except ExpatError:
             raise AssertionError("Error in serializer.set_properties")
 


### PR DESCRIPTION
This change simplifies the serializing of galicaster-specific properties to the mediapackage
It also helps if there is a need to add properties that are not strings (like annotations)