### PR TITLE
Decouple pausedialog from recorder ui

### DIFF
--- a/galicaster/classui/recorderui.py
+++ b/galicaster/classui/recorderui.py
@@ -252,6 +252,9 @@ class RecorderClassUI(Gtk.Box):
         self.pause_dialog.destroy()
         Gdk.threads_leave()
 
+    def hide_pause_dialog(self):
+        self.pause_dialog.destroy()
+
     def create_pause_dialog(self, parent):
         gui = Gtk.Builder()
         gui.add_from_file(get_ui_path("paused.glade"))
@@ -694,8 +697,6 @@ class RecorderClassUI(Gtk.Box):
         swapb = self.gui.get_object("swapbutton")
 
         if status == INIT_STATUS:
-            if self.pause_dialog:
-                self.pause_dialog.destroy()
             record.set_sensitive(False)
             pause.set_sensitive(False)
             stop.set_sensitive(False)
@@ -735,7 +736,6 @@ class RecorderClassUI(Gtk.Box):
             prevb.set_sensitive(False)
             helpb.set_sensitive(False)
             editb.set_sensitive(False)
-            GLib.idle_add(self.show_pause_dialog)
 
         elif status == ERROR_STATUS:
             record.set_sensitive(False)
@@ -746,6 +746,12 @@ class RecorderClassUI(Gtk.Box):
             editb.set_sensitive(False)
             if self.focus_is_active:
                 self.launch_error_message()
+
+        if status == PAUSED_STATUS:
+            GLib.idle_add(self.show_pause_dialog)
+        else:
+            if self.pause_dialog:
+                GLib.idle_add(self.hide_pause_dialog)
 
         # Change status label
         if status in STATUSES:

--- a/galicaster/classui/recorderui.py
+++ b/galicaster/classui/recorderui.py
@@ -23,7 +23,7 @@ TODO:
 """
 
 from gi.repository import GObject
-from gi.repository import Gtk, Gdk, GdkPixbuf
+from gi.repository import Gtk, Gdk, GdkPixbuf, GLib
 from gi.repository import Pango
 import datetime
 
@@ -244,11 +244,13 @@ class RecorderClassUI(Gtk.Box):
             logger.debug("Pausing Recording")
             self.recorder.pause()
 
-            self.pause_dialog = self.create_pause_dialog(self.get_toplevel())
-            if self.pause_dialog.run() == 1:
-                self.on_pause(None)
-            self.pause_dialog.destroy()
-
+    def show_pause_dialog(self):
+        self.pause_dialog = self.create_pause_dialog(self.get_toplevel())
+        Gdk.threads_enter()
+        if self.pause_dialog.run() == 1:
+            self.on_pause(None)
+        self.pause_dialog.destroy()
+        Gdk.threads_leave()
 
     def create_pause_dialog(self, parent):
         gui = Gtk.Builder()
@@ -733,6 +735,7 @@ class RecorderClassUI(Gtk.Box):
             prevb.set_sensitive(False)
             helpb.set_sensitive(False)
             editb.set_sensitive(False)
+            GLib.idle_add(self.show_pause_dialog)
 
         elif status == ERROR_STATUS:
             record.set_sensitive(False)


### PR DESCRIPTION
When calling `recorder.pause()` from a plugin the recorder pauses but the pause dialog doesn't appear because the pause dialog is only displayed when the clicked event of the pause button fires.
To decouple the pause dialog from the `recorderui` button events, this PR makes the pause dialog appear when the state of the recorder changes to paused and disappear when the state changes to anything other than paused.

Here's a simple plugin to do a one time test of pausing and unpausing the recorder without using the `recorderui` pause button:

```
import time
import threading

from galicaster.core import context

dispatcher = context.get_dispatcher()
recorder = context.get_recorder()

test_finished = False

def init():
    dispatcher.connect('recorder-started', on_recorder_started)

def on_recorder_started(sender=None, mp_id=None):
    if not test_finished:
        t = threading.Thread(target=pause)
        t.start()

def pause():
    global test_finished
    time.sleep(5)
    recorder.pause()
    time.sleep(5)
    recorder.resume()
    test_finished = True
```