### PR TITLE
Added a configurable setting to control the start of the scheduler service

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -66,6 +66,9 @@ address =
 ca-parameters =
 ignore_capture_devices = False
 
+[scheduler]
+active = True ; DEFAULT
+
 ;; OPENCAST SERIES
 ;; This section sets allows filtering series shown in the drop down list of the metadata editor.
 ;; It accepts most of the filter values that Opencast endpoint accepts, namely:

--- a/galicaster/scheduler/scheduler.py
+++ b/galicaster/scheduler/scheduler.py
@@ -20,6 +20,8 @@ from galicaster.mediapackage import mediapackage
 This class manages the timers and its respective signals in order to start and stop scheduled recordings.
 """
 
+DEFAULT_SCHEDULER_ACTIVE = True
+
 class Scheduler(object):
 
     def __init__(self, repo, conf, disp, logger, recorder):
@@ -52,8 +54,11 @@ class Scheduler(object):
         self.start_timers = dict()
         self.mp_rec = None
 
-        self.dispatcher.connect("timer-long", self._check_next_recording)
+        self.active     = conf.get('scheduler', 'active') or DEFAULT_SCHEDULER_ACTIVE
+        self.logger.debug('scheduler is active: %r' % self.active)
 
+        if self.active:
+            self.dispatcher.connect("timer-long", self._check_next_recording)
 
     def _check_next_recording(self, origin):
         next_mp = self.repo.get_next_mediapackage()


### PR DESCRIPTION
As a administrator I might have a plugin on a particular capture agent that responds to user input and changes the media package/event/series accordingly.

I do not want a scheduled event from Opencast to overwrite this change and I don't want the capture agent to be scheduled from Opencast.

Adding this configuration enables me as an Administrator to disable the schedule service.