### PR TITLE
Added a configuration parameter to define minimum lenght for recording to be ingested

### DIFF
--- a/conf-dist.ini
+++ b/conf-dist.ini
@@ -65,6 +65,7 @@ address =
 ;Dict of parameters used as configuration
 ca-parameters =
 ignore_capture_devices = False
+min-length = 0 ; Required minimum duration in seconds for a recording to be ingested (0 - no minimum)
 
 ;; OPENCAST SERIES
 ;; This section sets allows filtering series shown in the drop down list of the metadata editor.

--- a/galicaster/core/context.py
+++ b/galicaster/core/context.py
@@ -203,7 +203,8 @@ def get_worker():
                                                 not legacy,
                                                 get_conf().get('sidebyside', 'layout'),
                                                 get_conf().get_list('operations', 'hide'),
-                                                get_conf().get_list('operations', 'hide_nightly'))
+                                                get_conf().get_list('operations', 'hide_nightly'),
+                                                get_conf().get_int('ingest', 'min-length', 0))
 
     return __galicaster_context['worker']
 


### PR DESCRIPTION
As an Administrator I want to be able to configure a capture agent so that when a recording is less than a defined number of seconds it should not ingest as this might cause a processing failure in opencast.